### PR TITLE
Fix Amplify build: Remove subfont from build process

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "astro build && npx pagefind --site dist && subfont -ir --no-fallbacks --root dist",
+    "build": "astro build && npx pagefind --site dist",
     "preview": "astro preview",
     "pretty": "prettier --write ."
   },


### PR DESCRIPTION
## Summary

Fixes Amplify deployment failure by removing the `subfont` font optimization step from the build process.

## Problem

The Amplify build was failing during the `subfont` step with errors like:
```
ENOENT: no such file or directory, open 'dist/blog/*/~/assets/images/...'
```

Subfont was encountering broken image references in old blog posts with invalid paths like `~/assets/images/...` that don't exist in the build output.

## Solution

Removed `subfont` from the build script:
- **Before:** `astro build && npx pagefind --site dist && subfont -ir --no-fallbacks --root dist`
- **After:** `astro build && npx pagefind --site dist`

## Impact

- ✅ Fixes Amplify deployment
- ✅ Core functionality intact (Astro build + Pagefind search)
- ⚠️ Font subset optimization removed (minor performance trade-off)
- 📦 Subfont package remains in dependencies for potential future use

## Testing

- [x] Local build successful
- [x] Pagefind search indexing works
- [x] Waiting for Amplify deployment confirmation

## Related

- Follows PR #27 (merged)
- Part of Amplify optimization work

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)