### PR TITLE
Fix Pagefind search deployment

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -15,4 +15,3 @@ frontend:
     paths:
       - node_modules/**/*
       - .astro/**/*
-      - dist/_astro/**/*


### PR DESCRIPTION
## Summary

Fixes Pagefind search functionality not working in deployed Amplify builds by removing dist directory from cache paths.

## Problem

After deployment, the `/search` page shows:
```
🔍 Search is only available in production builds
```

This error occurs when Pagefind files (`/pagefind/pagefind.js`, `/pagefind/pagefind-ui.js`) are not found in the deployed build, even though:
- Build completes successfully
- `npm run build` includes `npx pagefind --site dist`
- Pagefind files exist locally in `dist/pagefind/`

## Root Cause

The `amplify.yml` cache configuration included `dist/_astro/**/*` which can cause issues with deploying generated assets that aren't in the cached paths, specifically the `pagefind/` directory.

## Solution

Removed `dist/_astro/**/*` from cache paths:
- **Before:** Cached `node_modules`, `.astro`, and `dist/_astro`
- **After:** Only cache `node_modules` and `.astro`

This ensures:
- ✅ All build artifacts in `dist/` are freshly generated and deployed
- ✅ Pagefind index files are included in deployment  
- ✅ node_modules and Astro cache still provide build speed improvements
- ✅ Clean deployments without stale cached assets

## Testing

- [x] Local build produces pagefind files in `dist/pagefind/`
- [x] Build script includes `npx pagefind --site dist`
- [ ] Waiting for Amplify deployment to verify search works

## Related

- Follows PR #28 (subfont removal)
- Part of Amplify optimization work

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)